### PR TITLE
Fix bug when multiple tags and digest path present [semver:patch]

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -37,5 +37,6 @@ steps:
 
         if [ -n "<<parameters.digest-path>>" ]; then
           mkdir -p "$(dirname <<parameters.digest-path>>)"
-          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> > "<<parameters.digest-path>>"
+          IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:"${DOCKER_TAGS[0]}" > "<<parameters.digest-path>>"
         fi


### PR DESCRIPTION
When providing both multiple tags and a digest path in `docker/push`,
the digest lookup would previously fail with `invalid reference format`
as it would append all the tags.  Fixed by always now using the first
tag for the digest lookup.
