### PR TITLE
Add tag-after-deploy hook for better tagging

### DIFF
--- a/src/commands/tag-after-deploy.yml
+++ b/src/commands/tag-after-deploy.yml
@@ -1,0 +1,29 @@
+description: Tag a Docker image after it has been pushed
+
+parameters:
+
+  image:
+    type: string
+    default: $IMAGE_NAME
+    description: >
+      Name of image to build, defaults to the value of
+      the $IMAGE_NAME variable (which is set during the
+      publish job to be whatever was set as the image
+      name there)
+
+  tag:
+    type: string
+    description: >
+      Comma-separated list of image tags to be added after
+      the docker image has been pushed (e.g. version numbers
+      of software installed on the image, which can only be
+      known after building the image, not before)
+
+steps:
+  - run:
+      name: tag
+      command: |
+        IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+        for tag in "${DOCKER_TAGS[@]}"; do
+          docker tag <<parameters.image>> <<parameters.image>>:${tag}
+        done

--- a/src/examples/with-tags-after-deploy.yml
+++ b/src/examples/with-tags-after-deploy.yml
@@ -1,5 +1,6 @@
 description: >
-  Build/publish a Docker image with multiple tags at build time
+  Build/publish a Docker image with multiple tags after deploy
+  as well as at build time
 
 usage:
   version: 2.1
@@ -11,5 +12,5 @@ usage:
     build-docker-image-only:
       jobs:
         - docker/publish:
-            image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
             tag: tag1,tag2,tag3
+            tag_after_deploy: tag4,tag5,tag6

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -64,6 +64,15 @@ parameters:
       Comma-separated list of image tags, defaults are:
       latest,CIRCLECI-$CIRCLE_BUILD_NUM,GIT-COMMIT-$CIRCLE_SHA1
 
+  tag_after_deploy:
+    type: string
+    default: ""
+    description: >
+      Comma-separated list of image tags to be added after
+      the image has been pushed (e.g. version numbers
+      of software installed on the image, which can only be
+      known after building the image, not before)
+
   registry:
     type: string
     default: docker.io
@@ -138,6 +147,13 @@ steps:
         source "$BASH_ENV"
         echo "DEFAULT_IMAGE_NAME environment variable set: $default_image_name"
 
+  - run:
+      name: Export image name
+      command: |
+        echo "export IMAGE_NAME=<<parameters.image>>" >> "$BASH_ENV"
+        source "$BASH_ENV"
+        echo "IMAGE_NAME environment variable set: <<parameters.image>>"
+
   - when:
       name: Run after_checkout lifecycle hook steps
       condition: <<parameters.after_checkout>>
@@ -190,9 +206,18 @@ steps:
         - store_artifacts:
             path: /tmp/digest.txt
             destination: docker/digest.txt
-        - run:
-            name: list all the tags
-            command: docker images <<parameters.image>> --format="{{ .Tag }}" | tee -a  "/tmp/tags.txt"
-        - store_artifacts:
-            path: /tmp/tags.txt
-            destination: docker/tags.txt
+
+  - when:
+      name: Add tags that can only be added after deploy
+      condition: <<parameters.tag_after_deploy>>
+      steps:
+        - tag-after-deploy:
+            tag: <<parameters.tag_after_deploy>>
+
+  - run:
+      name: list all the tags
+      command: docker images <<parameters.image>> --format="{{ .Tag }}" | tee -a  "/tmp/tags.txt"
+
+  - store_artifacts:
+      path: /tmp/tags.txt
+      destination: docker/tags.txt


### PR DESCRIPTION
It is important to be able to add tags easily after
the docker image has been pushed (e.g. version numbers
of software installed on the image, which can only be
known after building the image, not before).

By adding a `tag-after-deploy` hook into the `publish`
job, it makes the tagging very clean in terms of config, e.g.

```
jobs:
    - docker/publish:
        tag_after_deploy: tag1,tag2
```