### PR TITLE
Fix unwanted suppression of docker tagging errors

### DIFF
--- a/src/commands/tag-after-build.yml
+++ b/src/commands/tag-after-build.yml
@@ -28,7 +28,10 @@ steps:
   - run:
       name: <<parameters.step-name>>
       command: |
-        IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+        # set the tag as a variable because if we just use parameters.tag in the loop,
+        # then any errors will be suppressed
+        dockerTags="<< parameters.tag >>"
+        IFS="," read -ra DOCKER_TAGS \<<< "$dockerTags"
         for tag in "${DOCKER_TAGS[@]}"; do
           docker tag <<parameters.image>> <<parameters.image>>:${tag}
         done


### PR DESCRIPTION
Create an intermediary variable to capture the value of the tag
parameter, as doing so will cause the build to fail if there is an
error. (Whereas passing the tag parameter straight in to the IFS read
loop, as was the case until this commit, suppresses any errors)
