### PR TITLE
Lower case tags to match official base images

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -59,10 +59,10 @@ parameters:
 
   tag:
     type: string
-    default: latest,GIT-COMMIT-$CIRCLE_SHA1,CIRCLECI-$CIRCLE_BUILD_NUM
+    default: latest,git-commit-$CIRCLE_SHA1,circleci-$CIRCLE_BUILD_NUM
     description: >
       Comma-separated list of image tags, defaults are:
-      latest,CIRCLECI-$CIRCLE_BUILD_NUM,GIT-COMMIT-$CIRCLE_SHA1
+      latest,circleci-$CIRCLE_BUILD_NUM,git-commit-$CIRCLE_SHA1
 
   tag_after_build:
     type: string


### PR DESCRIPTION
The official CircleCI image tags are in lower case[1], not upper.  We
should match this, to be consistent.

[1] See the tags for the official CircleCI golang image, for instance:
https://hub.docker.com/r/circleci/golang/tags

